### PR TITLE
Add a break statement to fix blastn nogapped output

### DIFF
--- a/src/genpaf.c
+++ b/src/genpaf.c
@@ -1501,6 +1501,7 @@ void print_genpaf_match
 			case genpafEnd1Blast:
 				if (strand2 == strand1) fprintf (f, unsposFmt, start1-1 + length);
 				                   else fprintf (f, unsposFmt, start1);
+				break;
 			case genpafLength1:
 				fprintf (f, unsposFmt, length);
 				break;


### PR DESCRIPTION
Possible fix for #3 

I think the break statement was simply missing so it was just adding extra info onto the end of the "query end" value there (see issue for details)