### PR TITLE
Debian patches

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -73,7 +73,7 @@ VERSION_FLAGS= \
 	-DSUBVERSION_REV="\"${SUBVERSION_REV}"\"
 
 
-CFLAGS = -O3 ${definedForAll} ${VERSION_FLAGS}
+CFLAGS += -O3 ${definedForAll} ${VERSION_FLAGS}
 
 
 srcFiles = lastz infer_scores \
@@ -93,29 +93,29 @@ incFiles = lastz.h infer_scores.h \
            utilities.h dna_utilities.h sequences.h capsule.h
 
 %.o: %.c version.mak ${incFiles}
-	${CC} -c ${CFLAGS} -Dscore_type=I $< -o $@
+	${CC} ${CPPFLAGS} -c ${CFLAGS} -Dscore_type=I $< -o $@
 
 %_D.o: %.c version.mak ${incFiles}
-	${CC} -c ${CFLAGS} -Dscore_type=D $< -o $@
+	${CC} ${CPPFLAGS} -c ${CFLAGS} -Dscore_type=D $< -o $@
 
 %_32.o: %.c version.mak ${incFiles}
-	${CC} -c ${CFLAGS} ${flagsFor32} $< -o $@
+	${CC} ${CPPFLAGS} -c ${CFLAGS} ${flagsFor32} $< -o $@
 
 %_40.o: %.c version.mak ${incFiles}
-	${CC} -c ${CFLAGS} ${flagsFor40} $< -o $@
+	${CC} ${CPPFLAGS} -c ${CFLAGS} ${flagsFor40} $< -o $@
 
 
 lastz: $(foreach part,${srcFiles},${part}.o)
-	${CC} $(foreach part,${srcFiles},${part}.o) -lm -o $@
+	${CC} ${LDFLAGS} $(foreach part,${srcFiles},${part}.o) -lm -o $@
 
 lastz_D: $(foreach part,${srcFiles},${part}_D.o)
-	${CC} $(foreach part,${srcFiles},${part}_D.o) -lm -o $@
+	${CC} ${LDFLAGS} $(foreach part,${srcFiles},${part}_D.o) -lm -o $@
 
 lastz_32: $(foreach part,${srcFiles},${part}_32.o)
-	${CC} $(foreach part,${srcFiles},${part}_32.o) -lm -o $@
+	${CC} ${LDFLAGS} $(foreach part,${srcFiles},${part}_32.o) -lm -o $@
 
 lastz_40: $(foreach part,${srcFiles},${part}_40.o)
-	${CC} $(foreach part,${srcFiles},${part}_40.o) -lm -o $@
+	${CC} ${LDFLAGS} $(foreach part,${srcFiles},${part}_40.o) -lm -o $@
 
 # cleanup
 


### PR DESCRIPTION
Greetings,

While working on the lastz package in Debian downstream, we accumulated several patches, some of which I believe might of interest to you.  You will find them in the present patch queue.  One patch is about making sure characters are signed when comparing to EOF; this is not the case on several architectures, like Aarch64.  Another fixes a couple of typos, and the last a build failure with gcc-15.  Thanks go to Andreas Tille for most of the items, I only tackled the gcc-15 part.

In addition, we also have a Debian specific change to help [propagate our standard compilation flags] in order to implement hardening, but I have kept that change out of the patch queue in case you were to consider exposure to custom build flags unwelcome by default.  I'm open to add the change to the patch queue if you think otherwise.

In hope this helps,
Étienne.

[propagate our standard compilation flags]: https://salsa.debian.org/med-team/lastz/-/blob/master/debian/patches/propagate_cflags.patch?ref_type=heads